### PR TITLE
Add FarHack Online 2026 hackathon

### DIFF
--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -14,10 +14,10 @@ export async function generateMetadata(): Promise<Metadata> {
   return {
     metadataBase: new URL(BASE_URL),
     title: "FarHack Online 2026",
-    description: 'Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents — top projects showcase live at FarCon Rome.',
+    description: 'Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents. Top projects showcase live at FarCon Rome.',
     openGraph: {
       title: "FarHack Online 2026",
-      description: 'Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents — top projects showcase live at FarCon Rome.',
+      description: 'Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents. Top projects showcase live at FarCon Rome.',
       images: [FARCON_ROME_2026_BANNER_IMG],
       url: FARHACK_ONLINE_URL,
       siteName: 'FarHack',
@@ -139,7 +139,7 @@ export default async function FarConRomePage() {
             >
               FarCon Rome
             </a>
-            {' '}in May 2026 — in front of the Farcaster community.
+            {' '}in May 2026, in front of the Farcaster community.
           </p>
           <p className="text-gray-400 mt-4 text-sm">
             Hosted by{' '}
@@ -161,6 +161,21 @@ export default async function FarConRomePage() {
               Builders Garden
             </a>
           </p>
+        </div>
+
+        <div className="text-center mt-8 border border-gray-800 rounded-xl p-8 bg-gray-900">
+          <h2 className={`text-2xl font-bold mb-3 ${funnelDisplay.className}`}>Not ready to hack yet?</h2>
+          <p className="text-gray-300 max-w-xl mx-auto">
+            Join our online bootcamp to learn the basics of building on Farcaster, from Miniapps to Agents, and get ready to hack.
+          </p>
+          <a
+            href="https://luma.com/f7ok6tbp"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-6 inline-block px-8 py-3 text-lg font-semibold text-white bg-gray-800 hover:bg-gray-700 rounded-xl ring-1 ring-gray-700 transition-colors"
+          >
+            Join the Bootcamp
+          </a>
         </div>
       </div>
     </main>

--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -12,7 +12,7 @@ export const viewport: Viewport = {
 export async function generateMetadata(): Promise<Metadata> {
   const FARHACK_ONLINE_URL = `${BASE_URL}/hackathons/farhack-online-2026`;
   return {
-    metadataBase: new URL(FARCON_ROME_2026_BANNER_IMG),
+    metadataBase: new URL(BASE_URL),
     title: "FarHack Online 2026",
     description: 'Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents — top projects showcase live at FarCon Rome.',
     openGraph: {
@@ -101,6 +101,14 @@ export default async function FarConRomePage() {
               Online
             </span>
           </div>
+          <a
+            href="https://forms.gle/kLgD3sdfAmn27tGq5"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-8 inline-block px-8 py-3 text-lg font-semibold text-white bg-violet-600 hover:bg-violet-500 rounded-xl transition-colors"
+          >
+            Apply Now
+          </a>
         </div>
 
         <div className="mb-12">

--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -104,8 +104,8 @@ export default async function FarConRomePage() {
         </div>
 
         <div className="mb-12">
-          <h2 className={`text-2xl font-bold mb-2 text-center ${funnelDisplay.className}`}>Three Tracks, One Goal</h2>
-          <p className="text-gray-400 text-center mb-8">Choose the track that fits your vision and start building.</p>
+          <h2 className={`text-2xl font-bold mb-2 text-center ${funnelDisplay.className}`}>All tracks lead to Rome</h2>
+          <p className="text-gray-400 text-center mb-8">Hack on what excites you. Every track leads to the stage in Rome.</p>
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
             {tracks.map((track) => (
               <div
@@ -131,7 +131,7 @@ export default async function FarConRomePage() {
             >
               FarCon Rome
             </a>
-            {' '}in May 2026 — in front of builders, founders, and the Farcaster community.
+            {' '}in May 2026 — in front of the Farcaster community.
           </p>
         </div>
       </div>

--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -65,7 +65,7 @@ const tracks = [
   },
   {
     name: "Agents",
-    description: "Build autonomous agents that bring intelligence to the Farcaster network — from content curation to onchain actions and beyond.",
+    description: "Build autonomous agents that bring intelligence to the Farcaster network, from content curation to agentic commerce and beyond.",
   },
 ];
 

--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -141,6 +141,26 @@ export default async function FarConRomePage() {
             </a>
             {' '}in May 2026 — in front of the Farcaster community.
           </p>
+          <p className="text-gray-400 mt-4 text-sm">
+            Hosted by{' '}
+            <a
+              href="https://farcaster.xyz/urbe-eth"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-purple-400 hover:text-purple-300 underline"
+            >
+              urbe.eth
+            </a>
+            {' '}and{' '}
+            <a
+              href="https://farcaster.xyz/builders-garden"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-purple-400 hover:text-purple-300 underline"
+            >
+              Builders Garden
+            </a>
+          </p>
         </div>
       </div>
     </main>

--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -1,0 +1,140 @@
+/* eslint-disable @next/next/no-img-element */
+import React from 'react';
+import { getHackathon } from '@/lib/data';
+import { Metadata, Viewport } from 'next';
+import { BASE_URL, FARCON_ROME_2026_BANNER_IMG, funnelDisplay, funnelSans, ICON_IMG } from '@/lib/utils';
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+};
+
+export async function generateMetadata(): Promise<Metadata> {
+  const FARHACK_ONLINE_URL = `${BASE_URL}/hackathons/farhack-online-2026`;
+  return {
+    metadataBase: new URL(FARCON_ROME_2026_BANNER_IMG),
+    title: "FarHack Online 2026",
+    description: 'Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents — top projects showcase live at FarCon Rome.',
+    openGraph: {
+      title: "FarHack Online 2026",
+      description: 'Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents — top projects showcase live at FarCon Rome.',
+      images: [FARCON_ROME_2026_BANNER_IMG],
+      url: FARHACK_ONLINE_URL,
+      siteName: 'FarHack',
+      locale: 'en_US',
+      type: 'website',
+    },
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-video-preview': -1,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
+    },
+    other: {
+      "fc:frame": JSON.stringify({
+        version: "next",
+        imageUrl: FARCON_ROME_2026_BANNER_IMG,
+        button: {
+          title: "View Hackathon",
+          action: {
+            type: "launch_frame",
+            name: "FarHack",
+            url: FARHACK_ONLINE_URL,
+            splashImageUrl: ICON_IMG,
+            splashBackgroundColor: "#000000",
+          },
+        },
+      })
+    }
+  } as Metadata;
+}
+
+const tracks = [
+  {
+    name: "Miniapps",
+    description: "Ship compact, powerful apps that live inside Farcaster. Think tools, games, and utilities that users reach for every day.",
+  },
+  {
+    name: "Clients",
+    description: "Reimagine how people experience Farcaster. Build a new client or push an existing one forward with fresh features and bold UX.",
+  },
+  {
+    name: "Agents",
+    description: "Build autonomous agents that bring intelligence to the Farcaster network — from content curation to onchain actions and beyond.",
+  },
+];
+
+export default async function FarConRomePage() {
+  const hackathon = await getHackathon('farhack-online-2026');
+
+  if (!hackathon) {
+    return (
+      <div className="flex items-center justify-center min-h-screen text-white text-2xl">
+        <p>Hackathon not found</p>
+      </div>
+    );
+  }
+
+  return (
+    <main className={`min-h-screen bg-black text-white ${funnelSans.className}`}>
+      <div className="max-w-4xl mx-auto px-4 py-12">
+        <div className="text-center mb-12">
+          <img
+            src={hackathon.square_image}
+            alt={hackathon.name}
+            className="w-32 h-32 mx-auto rounded-xl mb-6"
+          />
+          <h1 className={`text-4xl font-bold mb-4 ${funnelDisplay.className}`}>{hackathon.name}</h1>
+          <p className="text-xl text-gray-300 leading-relaxed max-w-2xl mx-auto">
+            Two weeks to build what&apos;s next for Farcaster. Pick a track, ship something great, and put your project in front of the community at FarCon Rome.
+          </p>
+          <div className="mt-6 flex items-center justify-center gap-3 flex-wrap">
+            <span className="px-4 py-1.5 text-sm font-medium text-violet-300 bg-violet-500/10 rounded-full ring-1 ring-violet-500/20">
+              April 2026
+            </span>
+            <span className="px-4 py-1.5 text-sm font-medium text-cyan-300 bg-cyan-500/10 rounded-full ring-1 ring-cyan-500/20">
+              Online
+            </span>
+          </div>
+        </div>
+
+        <div className="mb-12">
+          <h2 className={`text-2xl font-bold mb-2 text-center ${funnelDisplay.className}`}>Three Tracks, One Goal</h2>
+          <p className="text-gray-400 text-center mb-8">Choose the track that fits your vision and start building.</p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+            {tracks.map((track) => (
+              <div
+                key={track.name}
+                className="bg-gray-900 border border-gray-800 rounded-xl p-6"
+              >
+                <h3 className={`text-lg font-semibold mb-3 ${funnelDisplay.className}`}>{track.name}</h3>
+                <p className="text-sm text-gray-400 leading-relaxed">{track.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="text-center border border-gray-800 rounded-xl p-8 bg-gray-900">
+          <h2 className={`text-2xl font-bold mb-3 ${funnelDisplay.className}`}>From Screen to Stage</h2>
+          <p className="text-gray-300 max-w-xl mx-auto">
+            The standout projects won&apos;t just live online. They&apos;ll be showcased live at{' '}
+            <a
+              href="https://farcon.eu"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-purple-400 hover:text-purple-300 underline"
+            >
+              FarCon Rome
+            </a>
+            {' '}in May 2026 — in front of builders, founders, and the Farcaster community.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/lib/data.json
+++ b/lib/data.json
@@ -24,7 +24,7 @@
       "description": "Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents — top projects showcase live at FarCon Rome.",
       "start_date": "2026-04-01T00:00:00Z",
       "end_date": "2026-04-14T23:59:00Z",
-      "square_image": "https://i.imgur.com/m2qIvVE.png",
+      "square_image": "/farhack-online-2026.png",
       "slug": "farhack-online-2026"
     }
   ]

--- a/lib/data.json
+++ b/lib/data.json
@@ -17,6 +17,15 @@
       "end_date": "2025-05-02T12:30:00Z",
       "square_image": "https://i.imgur.com/AWLzIaQ.png",
       "slug": "builders-day-at-farcon-2025"
+    },
+    {
+      "id": 6,
+      "name": "FarHack Online 2026",
+      "description": "Two weeks to build the future of Farcaster. Hack on Miniapps, Clients, or Agents — top projects showcase live at FarCon Rome.",
+      "start_date": "2026-04-01T00:00:00Z",
+      "end_date": "2026-04-14T23:59:00Z",
+      "square_image": "https://i.imgur.com/m2qIvVE.png",
+      "slug": "farhack-online-2026"
     }
   ]
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,5 @@
 import { clsx, type ClassValue } from "clsx"
-import { Inter, Karla, Lora } from "next/font/google";
+import { Funnel_Display, Funnel_Sans, Inter, Karla, Lora } from "next/font/google";
 import { twMerge } from "tailwind-merge"
 
 export function cn(...inputs: ClassValue[]) {
@@ -20,6 +20,16 @@ export const karla = Karla({
   display: 'swap'
 });
 
+export const funnelSans = Funnel_Sans({
+  subsets: ['latin'],
+  display: 'swap',
+});
+
+export const funnelDisplay = Funnel_Display({
+  subsets: ['latin'],
+  display: 'swap',
+});
+
 const isDev = process.env.NODE_ENV === 'development';
 const port = process.env.PORT || 3000;
 const localUrl = `http://localhost:${port}`;
@@ -28,6 +38,7 @@ export const BASE_URL = isDev ? localUrl : 'https://farhack.xyz';
 
 export const BANNER_IMG = 'https://i.imgur.com/jhw0cQL.png';
 export const BUILDERS_DAY_FARCON_2025_BANNER_IMG = 'https://i.imgur.com/9b4Fbo2.png';
+export const FARCON_ROME_2026_BANNER_IMG = 'https://i.imgur.com/m2qIvVE.png';
 export const HACKING_GUIDE_BANNER_IMG = 'https://i.imgur.com/5TBXea9.png';
 export const ICON_IMG = `${BASE_URL}/icons/icon-512x512.png`;
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -38,7 +38,7 @@ export const BASE_URL = isDev ? localUrl : 'https://farhack.xyz';
 
 export const BANNER_IMG = 'https://i.imgur.com/jhw0cQL.png';
 export const BUILDERS_DAY_FARCON_2025_BANNER_IMG = 'https://i.imgur.com/9b4Fbo2.png';
-export const FARCON_ROME_2026_BANNER_IMG = 'https://i.imgur.com/m2qIvVE.png';
+export const FARCON_ROME_2026_BANNER_IMG = `${BASE_URL}/farhack-online-2026.png`;
 export const HACKING_GUIDE_BANNER_IMG = 'https://i.imgur.com/5TBXea9.png';
 export const ICON_IMG = `${BASE_URL}/icons/icon-512x512.png`;
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- Adds a new hackathon entry for **FarHack Online 2026** — a two-week online hackathon in April 2026
- Three tracks: **Miniapps**, **Clients**, and **Agents**
- Top projects showcase live at [FarCon Rome](https://farcon.eu) in May 2026
- Dedicated detail page with Funnel Sans / Funnel Display typography, colored badges, and Farcaster frame metadata

## Changes
- `lib/data.json` — new hackathon entry (id: 6, slug: `farhack-online-2026`)
- `lib/utils.ts` — added Funnel Sans & Funnel Display font exports, banner image constant
- `app/(main)/hackathons/farhack-online-2026/page.tsx` — new detail page with tracks, badges, and FarCon Rome showcase section

## Test plan
- [ ] Verify `/hackathons` listing shows the new hackathon with "Upcoming" badge
- [ ] Verify `/hackathons/farhack-online-2026` renders correctly with Funnel fonts, track cards, and badges
- [ ] Check OG metadata and Farcaster frame embed render properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)