### PR TITLE
feat(hackathons): swap Apply Now for Submit Project link

### DIFF
--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -144,6 +144,9 @@ export default async function FarConRomePage() {
             >
               Submit Project
             </a>
+            <p className="mt-4 text-sm text-muted-foreground">
+              Final submission deadline: <strong className="text-foreground">Sunday, April 26 · 11:59pm UTC</strong>
+            </p>
           </div>
         </div>
 

--- a/app/(main)/hackathons/farhack-online-2026/page.tsx
+++ b/app/(main)/hackathons/farhack-online-2026/page.tsx
@@ -137,12 +137,12 @@ export default async function FarConRomePage() {
               </span>
             </div>
             <a
-              href="https://forms.gle/kLgD3sdfAmn27tGq5"
+              href="https://forms.gle/mBpBx4Q5xsP7zyFN9"
               target="_blank"
               rel="noopener noreferrer"
               className="mt-10 inline-block px-10 py-3.5 text-lg font-semibold text-white bg-violet-600 hover:bg-violet-500 rounded-xl transition-colors duration-200 cursor-pointer shadow-lg shadow-violet-600/25 dark:shadow-violet-600/20"
             >
-              Apply Now
+              Submit Project
             </a>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace the FarHack Online 2026 hero CTA from **Apply Now** to **Submit Project**
- Point it to the new project submission form: https://forms.gle/mBpBx4Q5xsP7zyFN9

## Test plan
- [ ] Visit `/hackathons/farhack-online-2026` and confirm the hero CTA reads **Submit Project**
- [ ] Click the CTA and verify it opens the new Google Form in a new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)